### PR TITLE
Add commit description parsing to git backends

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,7 +8,8 @@ type Commit struct {
 	AuthorName   string
 	AuthorEmail  string
 	Date         time.Time
-	Message      string
+	Message      string // subject line (first line of the commit message)
+	Description  string // body (everything after the first blank line)
 	FilesChanged []FileStat
 }
 

--- a/internal/git/gogit.go
+++ b/internal/git/gogit.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strings"
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -121,12 +122,17 @@ func (it *goGitCommitIter) Next() (*Commit, error) {
 			}
 		}
 
+		subject, body, _ := strings.Cut(c.Message, "\n\n")
+		subject = strings.TrimRight(subject, "\n")
+		description := strings.TrimSpace(body)
+
 		return &Commit{
 			Hash:         c.Hash.String(),
 			AuthorName:   c.Author.Name,
 			AuthorEmail:  c.Author.Email,
 			Date:         c.Author.When,
-			Message:      c.Message,
+			Message:      subject,
+			Description:  description,
 			FilesChanged: files,
 		}, nil
 	}

--- a/internal/git/gogit_test.go
+++ b/internal/git/gogit_test.go
@@ -166,6 +166,98 @@ func TestHeadHash(t *testing.T) {
 	}
 }
 
+// initTestRepoWithDesc creates a temporary git repository with 2 commits,
+// the second of which includes a description body, for testing description parsing.
+func initTestRepoWithDesc(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test User",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test User",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.name", "Test User")
+	run("git", "config", "user.email", "test@example.com")
+
+	// First commit: subject only, no description.
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", "hello.txt")
+	run("git", "commit", "-m", "simple commit")
+
+	time.Sleep(time.Second)
+
+	// Second commit: subject + description body.
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello world\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", "hello.txt")
+	run("git", "commit", "-m", "commit with description", "-m", "This is the description body.")
+
+	return dir
+}
+
+func TestGoGitDescription(t *testing.T) {
+	repoPath := initTestRepoWithDesc(t)
+
+	repo, err := git.Open(repoPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer repo.Close()
+
+	iter, err := repo.Log("")
+	if err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	defer iter.Close()
+
+	var commits []git.Commit
+	for {
+		c, err := iter.Next()
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if c == nil {
+			break
+		}
+		commits = append(commits, *c)
+	}
+
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits, got %d", len(commits))
+	}
+
+	// Log returns newest first; commits[0] has the description.
+	withDesc := commits[0]
+	simple := commits[1]
+
+	if withDesc.Message != "commit with description" {
+		t.Errorf("expected subject %q, got %q", "commit with description", withDesc.Message)
+	}
+	if withDesc.Description != "This is the description body." {
+		t.Errorf("expected description %q, got %q", "This is the description body.", withDesc.Description)
+	}
+	if simple.Description != "" {
+		t.Errorf("expected empty description for subject-only commit, got %q", simple.Description)
+	}
+}
+
 // initTestRepo creates a temporary git repository with 2 commits for testing.
 func initTestRepo(t *testing.T) string {
 	t.Helper()

--- a/internal/git/native.go
+++ b/internal/git/native.go
@@ -54,7 +54,7 @@ func (r *nativeRepo) HeadHash() (string, error) {
 func (r *nativeRepo) Log(sinceHash string) (CommitIter, error) {
 	args := []string{
 		"-C", r.path, "log",
-		"--format=GITANALYTICS_COMMIT%n%H%n%aN%n%aE%n%aI%n%s",
+		"--format=GITANALYTICS_COMMIT%n%H%n%aN%n%aE%n%aI%n%s%n%b%nGITANALYTICS_ENDMETA",
 		"--numstat",
 	}
 	if sinceHash != "" {
@@ -138,6 +138,20 @@ func (it *nativeCommitIter) Next() (*Commit, error) {
 		return nil, fmt.Errorf("parsing date %q: %w", meta[3], err)
 	}
 
+	// Read description lines until the end marker.
+	var descLines []string
+	for {
+		line, ok := it.nextLine()
+		if !ok {
+			return nil, fmt.Errorf("unexpected end of git log output (expected GITANALYTICS_ENDMETA)")
+		}
+		if line == "GITANALYTICS_ENDMETA" {
+			break
+		}
+		descLines = append(descLines, line)
+	}
+	description := strings.TrimSpace(strings.Join(descLines, "\n"))
+
 	// Read numstat lines until next sentinel or EOF.
 	var files []FileStat
 	for {
@@ -167,6 +181,7 @@ func (it *nativeCommitIter) Next() (*Commit, error) {
 		AuthorEmail:  meta[2],
 		Date:         date,
 		Message:      meta[4],
+		Description:  description,
 		FilesChanged: files,
 	}, nil
 }

--- a/internal/git/native_test.go
+++ b/internal/git/native_test.go
@@ -142,6 +142,52 @@ func TestNativeLogSinceHash(t *testing.T) {
 	}
 }
 
+func TestNativeDescription(t *testing.T) {
+	repoPath := initTestRepoWithDesc(t)
+
+	repo, err := git.NativeOpen(repoPath)
+	if err != nil {
+		t.Fatalf("NativeOpen: %v", err)
+	}
+	defer repo.Close()
+
+	iter, err := repo.Log("")
+	if err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	defer iter.Close()
+
+	var commits []git.Commit
+	for {
+		c, err := iter.Next()
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if c == nil {
+			break
+		}
+		commits = append(commits, *c)
+	}
+
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits, got %d", len(commits))
+	}
+
+	// Log returns newest first; commits[0] has the description.
+	withDesc := commits[0]
+	simple := commits[1]
+
+	if withDesc.Message != "commit with description" {
+		t.Errorf("expected subject %q, got %q", "commit with description", withDesc.Message)
+	}
+	if withDesc.Description != "This is the description body." {
+		t.Errorf("expected description %q, got %q", "This is the description body.", withDesc.Description)
+	}
+	if simple.Description != "" {
+		t.Errorf("expected empty description for subject-only commit, got %q", simple.Description)
+	}
+}
+
 func TestNativeHeadHash(t *testing.T) {
 	repoPath := initTestRepo(t)
 

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS commits (
 	author_name  VARCHAR NOT NULL,
 	author_email VARCHAR NOT NULL,
 	committed_at TIMESTAMP NOT NULL,
-	message      VARCHAR NOT NULL
+	message      VARCHAR NOT NULL,
+	description  TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS file_stats (

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -36,8 +36,13 @@ func NewFromDB(db *sql.DB) store.Store {
 }
 
 func (s *sqliteStore) Init() error {
-	_, err := s.db.Exec(store.SchemaSQL)
-	return err
+	if _, err := s.db.Exec(store.SchemaSQL); err != nil {
+		return err
+	}
+	// Migrate existing databases: adds the description column if absent.
+	// SQLite returns an error when the column already exists; we ignore it.
+	_, _ = s.db.Exec(`ALTER TABLE commits ADD COLUMN description TEXT NOT NULL DEFAULT ''`)
+	return nil
 }
 
 func (s *sqliteStore) InsertCommits(commits []git.Commit) error {
@@ -48,8 +53,8 @@ func (s *sqliteStore) InsertCommits(commits []git.Commit) error {
 	defer tx.Rollback()
 
 	commitStmt, err := tx.Prepare(
-		`INSERT OR IGNORE INTO commits (hash, author_name, author_email, committed_at, message)
-		 VALUES (?, ?, ?, ?, ?)`)
+		`INSERT OR IGNORE INTO commits (hash, author_name, author_email, committed_at, message, description)
+		 VALUES (?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -64,7 +69,7 @@ func (s *sqliteStore) InsertCommits(commits []git.Commit) error {
 	defer fileStmt.Close()
 
 	for _, c := range commits {
-		_, err := commitStmt.Exec(c.Hash, c.AuthorName, c.AuthorEmail, c.Date, c.Message)
+		_, err := commitStmt.Exec(c.Hash, c.AuthorName, c.AuthorEmail, c.Date, c.Message, c.Description)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
This PR adds support for parsing and storing commit message descriptions (body text) in addition to subject lines across both git backends (go-git and native git). The description is now extracted, stored in the database, and available for analysis.

## Key Changes
- **Git model**: Extended `Commit` struct with a `Description` field to store the commit message body (text after the first blank line)
- **go-git backend**: Updated to split commit messages on the first double newline, extracting subject and description separately
- **Native git backend**: Modified git log format to include the body (`%b`) and added an end marker (`GITANALYTICS_ENDMETA`) for reliable parsing of multi-line descriptions
- **Database schema**: Added `description` column to the `commits` table with a migration in `Init()` to support existing databases
- **Database insertion**: Updated the insert statement to include the description field
- **Tests**: Added comprehensive test coverage (`TestGoGitDescription` and `TestNativeDescription`) with a shared helper function (`initTestRepoWithDesc`) that creates test repositories with both subject-only and subject+description commits

## Implementation Details
- The description is extracted by splitting on the first occurrence of `\n\n` (blank line separator)
- Descriptions are trimmed of leading/trailing whitespace
- The native backend uses `GITANALYTICS_ENDMETA` as a sentinel to reliably detect the end of the description body in the git log output
- Database migration gracefully handles existing databases by ignoring the error when the column already exists

https://claude.ai/code/session_01HJ7FLDkYneKyCiTtGHoRQ8