### PR TITLE
Apply file/directory exclusions to home page statistics

### DIFF
--- a/app.go
+++ b/app.go
@@ -423,7 +423,8 @@ func relativeTime(t time.Time) string {
 
 // DashboardStats returns aggregate commit and file-change stats between the
 // given dates. Dates should be in "2006-01-02" format.
-func (a *App) DashboardStats(fromDate, toDate string) (*query.DashboardStats, error) {
+// Files matching any of the excludeGlobs patterns are omitted from file-level metrics.
+func (a *App) DashboardStats(fromDate, toDate string, excludeGlobs []string) (*query.DashboardStats, error) {
 	if a.db == nil {
 		return nil, fmt.Errorf("no repository open")
 	}
@@ -437,7 +438,7 @@ func (a *App) DashboardStats(fromDate, toDate string) (*query.DashboardStats, er
 		return nil, fmt.Errorf("parsing to date: %w", err)
 	}
 
-	return query.GetDashboardStats(a.db, from, to)
+	return query.GetDashboardStats(a.db, from, to, excludeGlobs)
 }
 
 // CommitsByHour returns per-hour commit counts between the given dates.

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -39,7 +39,7 @@
   },
   "overrides": [
     {
-      "includes": ["*.vue"],
+      "includes": ["**/*.vue"],
       "linter": {
         "rules": {
           "correctness": {

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -4,13 +4,18 @@ import { BarChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
-import { onMounted, ref } from 'vue'
+import { inject, onMounted, type Ref, ref, watch } from 'vue'
 import VChart from 'vue-echarts'
 import { CommitsByHour, DashboardStats, RepoInfo } from '../../wailsjs/go/main/App'
 import CommitHeatmap from '../components/CommitHeatmap.vue'
+import ExcludeFilter from '../components/ExcludeFilter.vue'
 import { formatDate } from '../composables/useDateRange'
+import { useExcludePatterns } from '../composables/useExcludePatterns'
 
 use([BarChart, GridComponent, TooltipComponent, CanvasRenderer])
+
+const repoPath = inject<Ref<string>>('repoPath', ref(''))
+const { patterns, addPattern, removePattern } = useExcludePatterns(repoPath)
 
 const repoInfo = ref<{
   name: string
@@ -36,6 +41,78 @@ function formatNumber(n: number): string {
   return n.toLocaleString()
 }
 
+async function loadStats(fromStr: string, toStr: string) {
+  const [dashStats, hourData] = await Promise.all([
+    DashboardStats(fromStr, toStr, patterns.value),
+    CommitsByHour(fromStr, toStr),
+  ])
+
+  stats.value = dashStats
+
+  // Build full 24-hour array from sparse data
+  const counts = new Array(24).fill(0)
+  if (hourData) {
+    for (const b of hourData) {
+      counts[b.hour] = b.count
+    }
+  }
+
+  chartOption.value = {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter(params: unknown) {
+        const p = Array.isArray(params) ? params[0] : params
+        const item = p as { dataIndex: number; value: number }
+        const label = `${String(item.dataIndex).padStart(2, '0')}:00`
+        return `${label}<br/>${item.value} commit${item.value === 1 ? '' : 's'}`
+      },
+    },
+    grid: {
+      left: 40,
+      right: 16,
+      top: 8,
+      bottom: 24,
+    },
+    xAxis: {
+      type: 'category',
+      data: Array.from({ length: 24 }, (_, i) => `${String(i).padStart(2, '0')}`),
+      axisLabel: {
+        color: '#8b949e',
+        fontSize: 11,
+        interval: 2,
+      },
+      axisLine: { lineStyle: { color: '#30363d' } },
+      axisTick: { show: false },
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: 1,
+      axisLabel: { color: '#8b949e', fontSize: 11 },
+      splitLine: { lineStyle: { color: '#21262d' } },
+    },
+    series: [
+      {
+        type: 'bar',
+        data: counts,
+        itemStyle: { color: '#58a6ff', borderRadius: [2, 2, 0, 0] },
+        barMaxWidth: 20,
+      },
+    ],
+  }
+}
+
+let fromStr = ''
+let toStr = ''
+
+watch(patterns, () => {
+  if (fromStr && toStr) {
+    loadStats(fromStr, toStr).catch((e: unknown) => {
+      error.value = e instanceof Error ? e.message : String(e)
+    })
+  }
+})
+
 onMounted(async () => {
   try {
     const to = new Date()
@@ -43,69 +120,15 @@ onMounted(async () => {
     const from = new Date()
     from.setDate(from.getDate() - 29) // 30 days including today
 
-    const fromStr = formatDate(from)
-    const toStr = formatDate(to)
+    fromStr = formatDate(from)
+    toStr = formatDate(to)
 
-    const [info, dashStats, hourData] = await Promise.all([
+    const [info] = await Promise.all([
       RepoInfo(),
-      DashboardStats(fromStr, toStr),
-      CommitsByHour(fromStr, toStr),
+      loadStats(fromStr, toStr),
     ])
 
     repoInfo.value = info
-    stats.value = dashStats
-
-    // Build full 24-hour array from sparse data
-    const counts = new Array(24).fill(0)
-    if (hourData) {
-      for (const b of hourData) {
-        counts[b.hour] = b.count
-      }
-    }
-
-    chartOption.value = {
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: { type: 'shadow' },
-        formatter(params: unknown) {
-          const p = Array.isArray(params) ? params[0] : params
-          const item = p as { dataIndex: number; value: number }
-          const label = `${String(item.dataIndex).padStart(2, '0')}:00`
-          return `${label}<br/>${item.value} commit${item.value === 1 ? '' : 's'}`
-        },
-      },
-      grid: {
-        left: 40,
-        right: 16,
-        top: 8,
-        bottom: 24,
-      },
-      xAxis: {
-        type: 'category',
-        data: Array.from({ length: 24 }, (_, i) => `${String(i).padStart(2, '0')}`),
-        axisLabel: {
-          color: '#8b949e',
-          fontSize: 11,
-          interval: 2,
-        },
-        axisLine: { lineStyle: { color: '#30363d' } },
-        axisTick: { show: false },
-      },
-      yAxis: {
-        type: 'value',
-        minInterval: 1,
-        axisLabel: { color: '#8b949e', fontSize: 11 },
-        splitLine: { lineStyle: { color: '#21262d' } },
-      },
-      series: [
-        {
-          type: 'bar',
-          data: counts,
-          itemStyle: { color: '#58a6ff', borderRadius: [2, 2, 0, 0] },
-          barMaxWidth: 20,
-        },
-      ],
-    }
   } catch (e: unknown) {
     error.value = e instanceof Error ? e.message : String(e)
   }
@@ -127,6 +150,11 @@ onMounted(async () => {
         {{ repoInfo.last_author }} &middot; {{ repoInfo.last_commit_age }} &middot;
         &ldquo;{{ repoInfo.last_message }}&rdquo;
       </div>
+    </div>
+
+    <!-- Exclusion Filter -->
+    <div class="filter-row">
+      <ExcludeFilter :patterns="patterns" @add="addPattern" @remove="removePattern" />
     </div>
 
     <!-- Stat Cards -->
@@ -212,6 +240,10 @@ onMounted(async () => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.filter-row {
+  margin-bottom: 16px;
 }
 
 /* Stat Cards */

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -123,10 +123,7 @@ onMounted(async () => {
     fromStr = formatDate(from)
     toStr = formatDate(to)
 
-    const [info] = await Promise.all([
-      RepoInfo(),
-      loadStats(fromStr, toStr),
-    ])
+    const [info] = await Promise.all([RepoInfo(), loadStats(fromStr, toStr)])
 
     repoInfo.value = info
   } catch (e: unknown) {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -14,7 +14,7 @@ export function CommitsByHour(arg1:string,arg2:string):Promise<Array<query.HourB
 
 export function Contributors(arg1:string,arg2:string,arg3:Array<string>):Promise<Array<query.Contributor>>;
 
-export function DashboardStats(arg1:string,arg2:string):Promise<query.DashboardStats>;
+export function DashboardStats(arg1:string,arg2:string,arg3:Array<string>):Promise<query.DashboardStats>;
 
 export function FileHotspots(arg1:string,arg2:string,arg3:Array<string>):Promise<Array<query.FileHotspot>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -22,8 +22,8 @@ export function Contributors(arg1, arg2, arg3) {
   return window['go']['main']['App']['Contributors'](arg1, arg2, arg3);
 }
 
-export function DashboardStats(arg1, arg2) {
-  return window['go']['main']['App']['DashboardStats'](arg1, arg2);
+export function DashboardStats(arg1, arg2, arg3) {
+  return window['go']['main']['App']['DashboardStats'](arg1, arg2, arg3);
 }
 
 export function FileHotspots(arg1, arg2, arg3) {

--- a/internal/query/dashboard.go
+++ b/internal/query/dashboard.go
@@ -15,8 +15,9 @@ type DashboardStats struct {
 }
 
 // GetDashboardStats returns aggregate commit and file-change stats between
-// from (inclusive) and to (exclusive).
-func GetDashboardStats(db *sql.DB, from, to time.Time) (*DashboardStats, error) {
+// from (inclusive) and to (exclusive). Files matching any of the excludeGlobs
+// patterns are omitted from file-level metrics (additions, deletions, files changed).
+func GetDashboardStats(db *sql.DB, from, to time.Time, excludeGlobs []string) (*DashboardStats, error) {
 	var s DashboardStats
 
 	err := db.QueryRow(
@@ -29,14 +30,16 @@ func GetDashboardStats(db *sql.DB, from, to time.Time) (*DashboardStats, error) 
 		return nil, err
 	}
 
+	excludeClause, excludeArgs := buildExcludeClauses("fs.file_path", excludeGlobs)
+	args := append([]any{from, to}, excludeArgs...)
 	err = db.QueryRow(
 		`SELECT COALESCE(SUM(fs.additions), 0),
 		        COALESCE(SUM(fs.deletions), 0),
 		        COUNT(DISTINCT fs.file_path)
 		 FROM file_stats fs
 		 JOIN commits c ON c.hash = fs.commit_hash
-		 WHERE c.committed_at >= ? AND c.committed_at < ?`,
-		from, to,
+		 WHERE c.committed_at >= ? AND c.committed_at < ?`+excludeClause,
+		args...,
 	).Scan(&s.Additions, &s.Deletions, &s.FilesChanged)
 	if err != nil {
 		return nil, err

--- a/internal/query/dashboard_test.go
+++ b/internal/query/dashboard_test.go
@@ -22,7 +22,7 @@ func TestGetDashboardStats_Basic(t *testing.T) {
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 
-	s, err := query.GetDashboardStats(db, from, to)
+	s, err := query.GetDashboardStats(db, from, to, nil)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestGetDashboardStats_Empty(t *testing.T) {
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 
-	s, err := query.GetDashboardStats(db, from, to)
+	s, err := query.GetDashboardStats(db, from, to, nil)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestGetDashboardStats_DateFiltering(t *testing.T) {
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 
-	s, err := query.GetDashboardStats(db, from, to)
+	s, err := query.GetDashboardStats(db, from, to, nil)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -86,6 +86,38 @@ func TestGetDashboardStats_DateFiltering(t *testing.T) {
 	}
 	if s.Additions != 10 {
 		t.Errorf("Additions: got %d, want 10", s.Additions)
+	}
+}
+
+func TestGetDashboardStats_ExcludeGlobs(t *testing.T) {
+	db := setupDB(t)
+
+	insertCommit(t, db, "aaa1", "Alice", "alice@example.com",
+		time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC), "first")
+	insertFileStat(t, db, "aaa1", "main.go", 10, 5)
+	insertFileStat(t, db, "aaa1", "vendor/lib.go", 100, 50)
+
+	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	s, err := query.GetDashboardStats(db, from, to, []string{"vendor/*"})
+	if err != nil {
+		t.Fatalf("GetDashboardStats: %v", err)
+	}
+
+	// Commit count is unaffected by file exclusions
+	if s.Commits != 1 {
+		t.Errorf("Commits: got %d, want 1", s.Commits)
+	}
+	// File-level stats exclude vendor/lib.go
+	if s.Additions != 10 {
+		t.Errorf("Additions: got %d, want 10", s.Additions)
+	}
+	if s.Deletions != 5 {
+		t.Errorf("Deletions: got %d, want 5", s.Deletions)
+	}
+	if s.FilesChanged != 1 {
+		t.Errorf("FilesChanged: got %d, want 1", s.FilesChanged)
 	}
 }
 


### PR DESCRIPTION
The home page was the only view that did not respect the globally configured file/directory exclusion patterns. This change wires the exclusion filter through to all three affected layers:

- internal/query/dashboard.go: GetDashboardStats now accepts excludeGlobs and applies them to file-level metrics (additions, deletions, files changed) via the existing buildExcludeClauses helper. Commit and contributor counts are intentionally unfiltered, consistent with how Contributors and other pages treat commit-level vs file-level data.
- app.go: DashboardStats method signature updated to accept and forward excludeGlobs.
- frontend: HomePage.vue now injects repoPath, uses useExcludePatterns, renders ExcludeFilter, and re-fetches stats reactively when patterns change. Wails JS bindings updated to match the new three-argument DashboardStats signature.
- internal/query/dashboard_test.go: existing tests updated to pass nil for excludeGlobs; new TestGetDashboardStats_ExcludeGlobs test added to verify file-level filtering.

https://claude.ai/code/session_015UmnVzceo5eymePEGeaRUT