### PR TITLE
Replace external links with native browser opening via Wails

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 Git Analytics is a desktop application that provides insights and visualizations for Git repositories.
 
 ## Prerequisites
-- Go 1.25
+- Go 1.26
 - Node 24
-- Wails 2.x
+- Wails 2.11.0
 
 ## Live Development
 

--- a/app.go
+++ b/app.go
@@ -19,6 +19,8 @@ import (
 	"git-analytics/internal/query"
 	"git-analytics/internal/store"
 	sqlitestore "git-analytics/internal/store/sqlite"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // App struct
@@ -39,6 +41,11 @@ func NewApp(version string) *App {
 // Version returns the application version string.
 func (a *App) Version() string {
 	return a.version
+}
+
+// OpenURL opens the given URL in the user's default browser.
+func (a *App) OpenURL(url string) {
+	runtime.BrowserOpenURL(a.ctx, url)
 }
 
 // UpdateInfo holds information about an available update.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { onMounted, provide, ref } from 'vue'
-import { CheckForUpdate, OpenRepository, SelectDirectory, Version } from '../wailsjs/go/main/App'
+import { CheckForUpdate, OpenRepository, OpenURL, SelectDirectory, Version } from '../wailsjs/go/main/App'
 import logoUrl from './assets/images/logo.png'
 import RecentReposList from './components/RecentReposList.vue'
 import RepoSelector from './components/RepoSelector.vue'
@@ -97,12 +97,12 @@ async function onOpenRecent(path: string) {
       <router-view v-else :key="repoPath" />
     </main>
     <footer v-if="appVersion">
-      <a href="https://github.com/tbrittain/git-analytics" target="_blank" rel="noopener">Git Analytics</a>
+      <button class="link-btn" @click="OpenURL('https://github.com/tbrittain/git-analytics')">Git Analytics</button>
       <span class="separator">·</span>
       <span>{{ appVersion }}</span>
-      <a v-if="updateURL" :href="updateURL" target="_blank" rel="noopener" class="update-link">
+      <button v-if="updateURL" class="link-btn update-link" @click="OpenURL(updateURL)">
         Update available: {{ updateTag }}
-      </a>
+      </button>
     </footer>
   </div>
 </template>
@@ -190,12 +190,19 @@ footer {
   flex-shrink: 0;
 }
 
-footer a {
+footer a,
+.link-btn {
   color: #8b949e;
   text-decoration: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
 }
 
-footer a:hover {
+footer a:hover,
+.link-btn:hover {
   color: #c9d1d9;
   text-decoration: underline;
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -22,6 +22,8 @@ export function FileOwnerships(arg1:string,arg2:string,arg3:Array<string>):Promi
 
 export function OpenRepository(arg1:string):Promise<void>;
 
+export function OpenURL(arg1:string):Promise<void>;
+
 export function RecentRepos():Promise<Array<config.RecentRepo>>;
 
 export function RemoveRecentRepo(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -38,6 +38,10 @@ export function OpenRepository(arg1) {
   return window['go']['main']['App']['OpenRepository'](arg1);
 }
 
+export function OpenURL(arg1) {
+  return window['go']['main']['App']['OpenURL'](arg1);
+}
+
 export function RecentRepos() {
   return window['go']['main']['App']['RecentRepos']();
 }


### PR DESCRIPTION
## Summary
This PR replaces HTML anchor tags with button elements that use the Wails runtime to open URLs in the user's default browser, improving the application's integration with the native desktop environment.

## Key Changes
- Added `OpenURL` method to the Go backend (`app.go`) that uses `runtime.BrowserOpenURL` to open URLs in the default browser
- Replaced two external links in the footer (GitHub repository and update link) with button elements that call the new `OpenURL` function
- Updated TypeScript/JavaScript bindings to expose the new `OpenURL` method to the frontend
- Added CSS styling for `.link-btn` class to maintain visual consistency with the previous anchor tag styling (color, hover effects, and button reset styles)

## Implementation Details
- The `OpenURL` function in `app.go` leverages Wails' built-in `runtime.BrowserOpenURL` for native browser integration
- Button elements are styled to appear and behave like links while using the native browser opening mechanism
- CSS includes proper button reset styles (`background: none`, `border: none`, `padding: 0`, `font: inherit`) to ensure consistent appearance across browsers
- Both JavaScript and TypeScript bindings were generated/updated to support the new backend method

https://claude.ai/code/session_01YVMEVED5BXdtMLsodRDLWR